### PR TITLE
Fix a problem causing streams in a pipeline to close unexpectedly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-
-const { spawn } = require('duplex-child-process');
+const ProcessStream = require('process-streams');
 const { execSync } = require('child_process');
 const fs = require('fs');
 const isZst = require('is-zst');
@@ -25,15 +24,17 @@ try {
 }
 
 exports.ZSTDCompress = function compress(compLevel, spawnOptions, streamOptions) {
+  const ps = new ProcessStream();
   let lvl = compLevel;
   if (!lvl) lvl = 3;
   if (lvl < 1 || lvl > 22) lvl = 3;
 
-  return spawn(bin, [`-${lvl}`], spawnOptions, streamOptions);
+  return ps.spawn(bin, [`-${lvl}`], spawnOptions, streamOptions);
 };
 
 exports.ZSTDDecompress = function decompress(spawnOptions, streamOptions) {
-  return spawn(bin, ['-d'], spawnOptions, streamOptions);
+  const ps = new ProcessStream();
+  return ps.spawn(bin, ['-d'], spawnOptions, streamOptions);
 };
 
 exports.ZSTDDecompressMaybe = function decompressMaybe(spawnOptions, streamOptions) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-zstd",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -756,10 +756,10 @@
         "is-obj": "^1.0.0"
       }
     },
-    "duplex-child-process": {
+    "duplex-maker": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/duplex-child-process/-/duplex-child-process-1.0.0.tgz",
-      "integrity": "sha1-SpSXQob7x4QNCFPSs/5ZCp20YUc="
+      "resolved": "https://registry.npmjs.org/duplex-maker/-/duplex-maker-1.0.0.tgz",
+      "integrity": "sha1-FgT4uUPLAGOm0+H+QqplETp52ko="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -2105,8 +2105,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-cancelable": {
       "version": "1.1.0",
@@ -2302,6 +2301,16 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "process-streams": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/process-streams/-/process-streams-1.0.1.tgz",
+      "integrity": "sha1-4iwqrb94jvDFdU6l4Ffphch91pE=",
+      "requires": {
+        "duplex-maker": "^1.0.0",
+        "quotemeta": "0.0.0",
+        "tempfile": "^1.1.0"
+      }
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2335,6 +2344,11 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "quotemeta": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/quotemeta/-/quotemeta-0.0.0.tgz",
+      "integrity": "sha1-UdOgbuD81uO1AdvSiQQ1Gtelo4w="
     },
     "rc": {
       "version": "1.2.8",
@@ -2948,6 +2962,22 @@
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^5.1.0"
           }
+        }
+      }
+    },
+    "tempfile": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
+      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
+      "requires": {
+        "os-tmpdir": "^1.0.0",
+        "uuid": "^2.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-zstd",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Node.js interface to the system installed zstd.",
   "main": "index.js",
   "scripts": {
@@ -37,7 +37,7 @@
     "release-it": "^12.4.1"
   },
   "dependencies": {
-    "duplex-child-process": "^1.0.0",
+    "process-streams": "^1.0.1",
     "is-zst": "^1.0.0",
     "peek-stream": "^1.1.3",
     "through2": "^3.0.1"


### PR DESCRIPTION
This can cause incomplete decompression or archive extraction in some situations, depending on timing of the underlying system.

Issue is caused by a race condition related to backpressure in streams and the way in which the underlying duplex-streams closes
it's internal stream objects upon the end of input from stfout of the child process.

Solution provided involves using the process-streams module instead of duplex-streams.