### PR TITLE
Fix string in require line to match package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ simple-zstd exposes a stream interfaces for compression and decompression.
 
 ```javascript
 const fs = require('fs');
-const {ZSTDCompress, ZSTDDecompress} = require('zstd');
+const {ZSTDCompress, ZSTDDecompress} = require('simple-zstd');
 
 // ZSTDCompress(compressionLevel, streamOptions)
 // ZSTDDecompress(streamOptions)
@@ -54,7 +54,7 @@ A maybe variant of decompress will pass-through a non-zst stream while decompres
 
 ```javascript
 const fs = require('fs');
-const {ZSTDDecompressMaybe} = require('zstd');
+const {ZSTDDecompressMaybe} = require('simple-zstd');
 
 // ZSTDDecompressMaybe(streamOptions)
 


### PR DESCRIPTION
Should be require('simple-zstd')