### PR TITLE
Create a way for passing additional arguments to the decompressor

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,14 +30,14 @@ exports.ZSTDCompress = function compress(compLevel, spawnOptions, streamOptions)
   return ps.spawn(bin, [`-${lvl}`], spawnOptions, streamOptions);
 };
 
-exports.ZSTDDecompress = function decompress(spawnOptions, streamOptions) {
+exports.ZSTDDecompress = function decompress(spawnOptions, streamOptions, zstdOptions = []) {
   const ps = new ProcessStream();
-  return ps.spawn(bin, ['-d'], spawnOptions, streamOptions);
+  return ps.spawn(bin, ['-d', ...zstdOptions], spawnOptions, streamOptions);
 };
 
-exports.ZSTDDecompressMaybe = function decompressMaybe(spawnOptions, streamOptions) {
+exports.ZSTDDecompressMaybe = function decompressMaybe(spawnOptions, streamOptions, zstdOptions = []) {
   return peek({ newline: false, maxBuffer: 10 }, (data, swap) => {
-    if (isZst(data)) return swap(null, exports.ZSTDDecompress(spawnOptions, streamOptions));
+    if (isZst(data)) return swap(null, exports.ZSTDDecompress(spawnOptions, streamOptions, zstdOptions));
     return swap(null, through());
   });
 };


### PR DESCRIPTION
I'm working with a particularly large dataset that requires `--long=31` be specified in the zstd decompressor options. This change allows that to be specified like so:
```js
require('simple-zstd').ZSTDDecompressMaybe(undefined, undefined, ['--long=31']);
```
and uses js default parameters to keep backwards compatibility.
