### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Stieneee/simple-zstd/security/code-scanning/1](https://github.com/Stieneee/simple-zstd/security/code-scanning/1)

The best way to fix this is to add a `permissions` block, explicitly setting the least privilege required. Since the jobs here only check out the code, build, and test, they do not require write permissions—only `contents: read` is needed. This block can be added either at the workflow root (to apply to all jobs) or inside each job. The most minimal and robust change is to add the following to the top of the workflow file, after `name:` and before `on:`:

```yaml
permissions:
  contents: read
```

Only the `.github/workflows/ci.yml` file needs to be changed, and no extra imports, dependencies, or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
