### PR TITLE
fix main/types.  remove linux only CLI tool.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "simple-zstd",
   "version": "2.0.0",
   "description": "Node.js interface to the system installed zstd.",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -13,10 +13,10 @@
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "timeout --signal=TERM --kill-after=5s 120s node --test --require ts-node/register test/test.ts || true",
-    "test-debug": "DEBUG=SimpleZSTD,SimpleZSTDQueue timeout --signal=TERM --kill-after=5s 120s node --test --require ts-node/register test/test.ts || true",
-    "test-ci": "timeout --signal=TERM --kill-after=5s 120s node --test --require ts-node/register test/test.ts && exit 0 || exit 1",
-    "coverage": "timeout --signal=TERM --kill-after=5s 120s node --test --experimental-test-coverage --require ts-node/register test/test.ts || true"
+    "test": "node --test --require ts-node/register test/test.ts || true",
+    "test-debug": "DEBUG=SimpleZSTD,SimpleZSTDQueue timeout -t 120s -- node --test --require ts-node/register test/test.ts || true",
+    "test-ci": "node --test --require ts-node/register test/test.ts && exit 0 || exit 1",
+    "coverage": "node --test --experimental-test-coverage --require ts-node/register test/test.ts || true"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #31 

Without this fix, 2.0.0 is just broken for most users.

I also removed linux-only CLI tool "timeout".